### PR TITLE
Add @rmenke/css-tokenizer-tests corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ You may also want to check out these other CSS parsing projects:
 - [csstree/csstree](https://github.com/csstree/csstree)
 - [tabatkins/parse-css](https://github.com/tabatkins/parse-css)
 - [asamuzaK/domSelector](https://github.com/asamuzaK/domSelector)
+- [dbushell/css](https://git.dbushell.com/dbushell/css)
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ You may also want to check out these other CSS parsing projects:
 - [tabatkins/parse-css](https://github.com/tabatkins/parse-css)
 - [asamuzaK/domSelector](https://github.com/asamuzaK/domSelector)
 - [dbushell/css](https://git.dbushell.com/dbushell/css)
+- [romainmenke/css-tokenizer-tests](https://github.com/romainmenke/css-tokenizer-tests)
 
 ## Acknowledgements
 
-Selery’s tokenizer is much more robust thanks to the test suite imported from [parse-css](https://github.com/tabatkins/parse-css).
+Selery’s tokenizer is much more robust thanks to the test suite imported from [parse-css](https://github.com/tabatkins/parse-css) and the [`@rmenke/css-tokenizer-tests`](https://github.com/romainmenke/css-tokenizer-tests) corpus.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.2.0",
 			"license": "MIT",
 			"devDependencies": {
+				"@rmenke/css-tokenizer-tests": "^1.2.0",
 				"esbuild": "^0.20.2",
 				"eslint": "^8.39.0",
 				"jsdom": "^24.0.0",
@@ -507,6 +508,13 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@rmenke/css-tokenizer-tests": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@rmenke/css-tokenizer-tests/-/css-tokenizer-tests-1.2.0.tgz",
+			"integrity": "sha512-XfdeXzW5QGc3inl69eid2FTLGY/514xs+VXQWlEzdUVm1QdU6MicU5S2hcEbHoC9WMzIMALTzxiZb49w+xJk0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/acorn": {
 			"version": "8.8.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	},
 	"homepage": "https://github.com/danburzo/selery",
 	"devDependencies": {
+		"@rmenke/css-tokenizer-tests": "^1.2.0",
 		"esbuild": "^0.20.2",
 		"eslint": "^8.39.0",
 		"jsdom": "^24.0.0",

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -558,9 +558,11 @@ export function tokenize(str) {
 			if (is_esc(-1)) {
 				_i--;
 				tokens.push(identlike());
-				continue;
+			} else {
+				// TODO: Parse error
+				tokens.push({ type: Tokens.Delim, value: ch, start, end: start });
 			}
-			throw new Error('Invalid escape');
+			continue;
 		}
 
 		if (ch === ']') {

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -33,7 +33,7 @@ function nonascii(c) {
 		(c >= 0x3001 && c <= 0xd7ff) ||
 		(c >= 0xf900 && c <= 0xfdcf) ||
 		(c >= 0xfdf0 && c <= 0xfffd) ||
-		c > 0x10000
+		c >= 0x10000
 	);
 }
 
@@ -160,7 +160,7 @@ export function tokenize(str) {
 		let num_token = {
 			value: '',
 			start,
-			numtype: 'integer'
+			valtype: 'integer'
 		};
 		if (chars[_i] === '+' || chars[_i] === '-') {
 			num_token.sign = chars[_i];
@@ -169,7 +169,7 @@ export function tokenize(str) {
 		num_token.value += digits();
 		if (chars[_i] === '.' && /\d/.test(chars[_i + 1] || '')) {
 			num_token.value += chars[_i++] + digits();
-			num_token.numtype = 'number';
+			num_token.valtype = 'number';
 		}
 		if (chars[_i] === 'e' || chars[_i] === 'E') {
 			if (
@@ -177,10 +177,10 @@ export function tokenize(str) {
 				/\d/.test(chars[_i + 2] || '')
 			) {
 				num_token.value += chars[_i++] + chars[_i++] + digits();
-				num_token.numtype = 'number';
+				num_token.valtype = 'number';
 			} else if (/\d/.test(chars[_i + 1] || '')) {
 				num_token.value += chars[_i++] + digits();
-				num_token.numtype = 'number';
+				num_token.valtype = 'number';
 			}
 		}
 		num_token.value = +num_token.value;
@@ -192,7 +192,7 @@ export function tokenize(str) {
 			num_token.type = Tokens.Percentage;
 			// According to 4.3.3. Consume a numeric token,
 			// percentages don’t use the `type` flag from the number.
-			delete num_token.numtype;
+			delete num_token.valtype;
 		} else {
 			num_token.type = Tokens.Number;
 		}
@@ -440,10 +440,11 @@ export function tokenize(str) {
 			if (_i < chars.length && (isIdentCodePoint(chars[_i]) || is_esc())) {
 				token = {
 					type: Tokens.Hash,
-					start
+					start,
+					valtype: 'unrestricted'
 				};
 				if (is_ident()) {
-					token.id = true;
+					token.valtype = 'id';
 				}
 				token.value = ident();
 				token.end = _i - 1;

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -159,7 +159,8 @@ export function tokenize(str) {
 	function num() {
 		let num_token = {
 			value: '',
-			start
+			start,
+			numtype: 'integer'
 		};
 		if (chars[_i] === '+' || chars[_i] === '-') {
 			num_token.sign = chars[_i];
@@ -168,6 +169,7 @@ export function tokenize(str) {
 		num_token.value += digits();
 		if (chars[_i] === '.' && /\d/.test(chars[_i + 1] || '')) {
 			num_token.value += chars[_i++] + digits();
+			num_token.numtype = 'number';
 		}
 		if (chars[_i] === 'e' || chars[_i] === 'E') {
 			if (
@@ -175,8 +177,10 @@ export function tokenize(str) {
 				/\d/.test(chars[_i + 2] || '')
 			) {
 				num_token.value += chars[_i++] + chars[_i++] + digits();
+				num_token.numtype = 'number';
 			} else if (/\d/.test(chars[_i + 1] || '')) {
 				num_token.value += chars[_i++] + digits();
+				num_token.numtype = 'number';
 			}
 		}
 		num_token.value = +num_token.value;
@@ -186,6 +190,9 @@ export function tokenize(str) {
 		} else if (chars[_i] === '%') {
 			_i++;
 			num_token.type = Tokens.Percentage;
+			// According to 4.3.3. Consume a numeric token,
+			// percentages don’t use the `type` flag from the number.
+			delete num_token.numtype;
 		} else {
 			num_token.type = Tokens.Number;
 		}

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -111,7 +111,8 @@ export function tokenize(str) {
 	*/
 	function esc() {
 		if (_i >= chars.length) {
-			throw new Error('Unexpected end of input, unterminated escape sequence');
+			// TODO: EOF, parser error
+			return '\uFFFD';
 		} else if (HexDigit.test(chars[_i] || '')) {
 			let hex = chars[_i++];
 			while (hex.length < 6 && HexDigit.test(chars[_i] || '')) {
@@ -369,7 +370,8 @@ export function tokenize(str) {
 				_i++;
 			}
 			if (_i === chars.length) {
-				throw new Error('Unexpected end of input, unterminated comment');
+				// TODO parse error
+				continue;
 			}
 			_i += 2; // consume end of comment
 			continue;

--- a/test/cases/anplusb.case.js
+++ b/test/cases/anplusb.case.js
@@ -44,7 +44,7 @@ export default [
 							unit: 'n',
 							start: 18,
 							end: 19,
-							numtype: 'integer'
+							valtype: 'integer'
 						},
 						{
 							type: 'number',
@@ -52,7 +52,7 @@ export default [
 							sign: '+',
 							start: 20,
 							end: 21,
-							numtype: 'integer'
+							valtype: 'integer'
 						}
 					],
 					start: 0,
@@ -78,7 +78,7 @@ export default [
 							value: 2,
 							start: 11,
 							end: 11,
-							numtype: 'integer'
+							valtype: 'integer'
 						},
 						{ type: 'whitespace', start: 12, end: 12 },
 						{ type: 'ident', value: 'of', start: 13, end: 14 },

--- a/test/cases/anplusb.case.js
+++ b/test/cases/anplusb.case.js
@@ -38,8 +38,22 @@ export default [
 					type: 'PseudoClassSelector',
 					identifier: 'nth-last-of-type',
 					argument: [
-						{ type: 'dimension', value: 2, unit: 'n', start: 18, end: 19 },
-						{ type: 'number', value: 3, sign: '+', start: 20, end: 21 }
+						{
+							type: 'dimension',
+							value: 2,
+							unit: 'n',
+							start: 18,
+							end: 19,
+							numtype: 'integer'
+						},
+						{
+							type: 'number',
+							value: 3,
+							sign: '+',
+							start: 20,
+							end: 21,
+							numtype: 'integer'
+						}
 					],
 					start: 0,
 					end: 22
@@ -59,7 +73,13 @@ export default [
 					type: 'PseudoClassSelector',
 					identifier: 'nth-child',
 					argument: [
-						{ type: 'number', value: 2, start: 11, end: 11 },
+						{
+							type: 'number',
+							value: 2,
+							start: 11,
+							end: 11,
+							numtype: 'integer'
+						},
 						{ type: 'whitespace', start: 12, end: 12 },
 						{ type: 'ident', value: 'of', start: 13, end: 14 },
 						{ type: 'whitespace', start: 15, end: 15 },

--- a/test/cases/comments.case.js
+++ b/test/cases/comments.case.js
@@ -30,8 +30,8 @@ export default [
 		serialize: 'a'
 	},
 	{
-		selector: '/* A comment \\',
-		tokenize: /unterminated comment/
+		selector: '/* Unterminated comment \\',
+		tokenize: []
 	},
 	{
 		selector: '/* A comment \\*/ a',

--- a/test/cases/misc.case.js
+++ b/test/cases/misc.case.js
@@ -16,11 +16,15 @@ export default [
 	},
 	{
 		selector: '#hello',
-		tokenize: [{ type: 'hash', id: true, value: 'hello', start: 0, end: 5 }]
+		tokenize: [
+			{ type: 'hash', valtype: 'id', value: 'hello', start: 0, end: 5 }
+		]
 	},
 	{
 		selector: '#he\\#llo',
-		tokenize: [{ type: 'hash', id: true, value: 'he#llo', start: 0, end: 7 }]
+		tokenize: [
+			{ type: 'hash', valtype: 'id', value: 'he#llo', start: 0, end: 7 }
+		]
 	},
 	{
 		selector: '# hello',

--- a/test/cases/numbers.case.js
+++ b/test/cases/numbers.case.js
@@ -6,30 +6,72 @@ export default [
 	{
 		selector: '1 -2 .3 0.4 -2.5e10 1e-5 1e+7',
 		tokenize: [
-			{ type: 'number', value: 1, start: 0, end: 0 },
+			{ type: 'number', value: 1, start: 0, end: 0, numtype: 'integer' },
 			{ type: 'whitespace', start: 1, end: 1 },
-			{ type: 'number', value: -2, sign: '-', start: 2, end: 3 },
+			{
+				type: 'number',
+				value: -2,
+				sign: '-',
+				start: 2,
+				end: 3,
+				numtype: 'integer'
+			},
 			{ type: 'whitespace', start: 4, end: 4 },
-			{ type: 'number', value: 0.3, start: 5, end: 6 },
+			{ type: 'number', value: 0.3, start: 5, end: 6, numtype: 'number' },
 			{ type: 'whitespace', start: 7, end: 7 },
-			{ type: 'number', value: 0.4, start: 8, end: 10 },
+			{ type: 'number', value: 0.4, start: 8, end: 10, numtype: 'number' },
 			{ type: 'whitespace', start: 11, end: 11 },
-			{ type: 'number', value: -2.5e10, sign: '-', start: 12, end: 18 },
+			{
+				type: 'number',
+				value: -2.5e10,
+				sign: '-',
+				start: 12,
+				end: 18,
+				numtype: 'number'
+			},
 			{ type: 'whitespace', start: 19, end: 19 },
-			{ type: 'number', value: 1e-5, start: 20, end: 23 },
+			{ type: 'number', value: 1e-5, start: 20, end: 23, numtype: 'number' },
 			{ type: 'whitespace', start: 24, end: 24 },
-			{ type: 'number', value: 1e7, start: 25, end: 28 }
+			{ type: 'number', value: 1e7, start: 25, end: 28, numtype: 'number' }
 		]
 	},
 	{
 		selector: '1em 2n-3 3n+2',
 		tokenize: [
-			{ type: 'dimension', value: 1, unit: 'em', start: 0, end: 2 },
+			{
+				type: 'dimension',
+				value: 1,
+				unit: 'em',
+				start: 0,
+				end: 2,
+				numtype: 'integer'
+			},
 			{ type: 'whitespace', start: 3, end: 3 },
-			{ type: 'dimension', value: 2, unit: 'n-3', start: 4, end: 7 },
+			{
+				type: 'dimension',
+				value: 2,
+				unit: 'n-3',
+				start: 4,
+				end: 7,
+				numtype: 'integer'
+			},
 			{ type: 'whitespace', start: 8, end: 8 },
-			{ type: 'dimension', value: 3, unit: 'n', start: 9, end: 10 },
-			{ type: 'number', value: 2, sign: '+', start: 11, end: 12 }
+			{
+				type: 'dimension',
+				value: 3,
+				unit: 'n',
+				start: 9,
+				end: 10,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: 2,
+				sign: '+',
+				start: 11,
+				end: 12,
+				numtype: 'integer'
+			}
 		]
 	}
 ];

--- a/test/cases/numbers.case.js
+++ b/test/cases/numbers.case.js
@@ -6,7 +6,7 @@ export default [
 	{
 		selector: '1 -2 .3 0.4 -2.5e10 1e-5 1e+7',
 		tokenize: [
-			{ type: 'number', value: 1, start: 0, end: 0, numtype: 'integer' },
+			{ type: 'number', value: 1, start: 0, end: 0, valtype: 'integer' },
 			{ type: 'whitespace', start: 1, end: 1 },
 			{
 				type: 'number',
@@ -14,12 +14,12 @@ export default [
 				sign: '-',
 				start: 2,
 				end: 3,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'whitespace', start: 4, end: 4 },
-			{ type: 'number', value: 0.3, start: 5, end: 6, numtype: 'number' },
+			{ type: 'number', value: 0.3, start: 5, end: 6, valtype: 'number' },
 			{ type: 'whitespace', start: 7, end: 7 },
-			{ type: 'number', value: 0.4, start: 8, end: 10, numtype: 'number' },
+			{ type: 'number', value: 0.4, start: 8, end: 10, valtype: 'number' },
 			{ type: 'whitespace', start: 11, end: 11 },
 			{
 				type: 'number',
@@ -27,12 +27,12 @@ export default [
 				sign: '-',
 				start: 12,
 				end: 18,
-				numtype: 'number'
+				valtype: 'number'
 			},
 			{ type: 'whitespace', start: 19, end: 19 },
-			{ type: 'number', value: 1e-5, start: 20, end: 23, numtype: 'number' },
+			{ type: 'number', value: 1e-5, start: 20, end: 23, valtype: 'number' },
 			{ type: 'whitespace', start: 24, end: 24 },
-			{ type: 'number', value: 1e7, start: 25, end: 28, numtype: 'number' }
+			{ type: 'number', value: 1e7, start: 25, end: 28, valtype: 'number' }
 		]
 	},
 	{
@@ -44,7 +44,7 @@ export default [
 				unit: 'em',
 				start: 0,
 				end: 2,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'whitespace', start: 3, end: 3 },
 			{
@@ -53,7 +53,7 @@ export default [
 				unit: 'n-3',
 				start: 4,
 				end: 7,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'whitespace', start: 8, end: 8 },
 			{
@@ -62,7 +62,7 @@ export default [
 				unit: 'n',
 				start: 9,
 				end: 10,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -70,7 +70,7 @@ export default [
 				sign: '+',
 				start: 11,
 				end: 12,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	}

--- a/test/cases/parse-css.case.js
+++ b/test/cases/parse-css.case.js
@@ -218,7 +218,7 @@ export default [
 		selector: '\r\n\f\t2',
 		tokenize: [
 			{ type: 'whitespace', start: 0, end: 2 },
-			{ type: 'number', value: 2, start: 3, end: 3 }
+			{ type: 'number', value: 2, start: 3, end: 3, numtype: 'integer' }
 		]
 	},
 
@@ -462,7 +462,7 @@ export default [
 		selector: 'scale(2)',
 		tokenize: [
 			{ type: 'function', value: 'scale', start: 0, end: 5 },
-			{ type: 'number', value: 2, start: 6, end: 6 },
+			{ type: 'number', value: 2, start: 6, end: 6, numtype: 'integer' },
 			{ type: ')', start: 7, end: 7 }
 		]
 	},
@@ -557,14 +557,21 @@ export default [
 		selector: '@2',
 		tokenize: [
 			{ type: 'delim', value: '@', start: 0, end: 0 },
-			{ type: 'number', value: 2, start: 1, end: 1 }
+			{ type: 'number', value: 2, start: 1, end: 1, numtype: 'integer' }
 		]
 	},
 	{
 		selector: '@-1',
 		tokenize: [
 			{ type: 'delim', value: '@', start: 0, end: 0 },
-			{ type: 'number', value: -1, sign: '-', start: 1, end: 2 }
+			{
+				type: 'number',
+				value: -1,
+				sign: '-',
+				start: 1,
+				end: 2,
+				numtype: 'integer'
+			}
 		]
 	},
 
@@ -830,96 +837,178 @@ export default [
 	// -- NumberToken
 	{
 		selector: '10',
-		tokenize: [{ type: 'number', value: 10, start: 0, end: 1 }]
+		tokenize: [
+			{ type: 'number', value: 10, start: 0, end: 1, numtype: 'integer' }
+		]
 	},
 	{
 		selector: '12.0',
-		tokenize: [{ type: 'number', value: 12, start: 0, end: 3 }]
+		tokenize: [
+			{ type: 'number', value: 12, start: 0, end: 3, numtype: 'number' }
+		]
 	},
 	{
 		selector: '+45.6',
-		tokenize: [{ type: 'number', value: 45.6, sign: '+', start: 0, end: 4 }]
+		tokenize: [
+			{
+				type: 'number',
+				value: 45.6,
+				sign: '+',
+				start: 0,
+				end: 4,
+				numtype: 'number'
+			}
+		]
 	},
 	{
 		selector: '-7',
-		tokenize: [{ type: 'number', value: -7, sign: '-', start: 0, end: 1 }]
+		tokenize: [
+			{
+				type: 'number',
+				value: -7,
+				sign: '-',
+				start: 0,
+				end: 1,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '010',
-		tokenize: [{ type: 'number', value: 10, start: 0, end: 2 }]
+		tokenize: [
+			{ type: 'number', value: 10, start: 0, end: 2, numtype: 'integer' }
+		]
 	},
 	{
 		selector: '10e0',
-		tokenize: [{ type: 'number', value: 10, start: 0, end: 3 }]
+		tokenize: [
+			{ type: 'number', value: 10, start: 0, end: 3, numtype: 'number' }
+		]
 	},
 	{
 		selector: '12e3',
-		tokenize: [{ type: 'number', value: 12000, start: 0, end: 3 }]
+		tokenize: [
+			{ type: 'number', value: 12000, start: 0, end: 3, numtype: 'number' }
+		]
 	},
 	{
 		selector: '3e+1',
-		tokenize: [{ type: 'number', value: 30, start: 0, end: 3 }]
+		tokenize: [
+			{ type: 'number', value: 30, start: 0, end: 3, numtype: 'number' }
+		]
 	},
 	{
 		selector: '12E-1',
-		tokenize: [{ type: 'number', value: 1.2, start: 0, end: 4 }]
+		tokenize: [
+			{ type: 'number', value: 1.2, start: 0, end: 4, numtype: 'number' }
+		]
 	},
 	{
 		selector: '.7',
-		tokenize: [{ type: 'number', value: 0.7, start: 0, end: 1 }]
+		tokenize: [
+			{ type: 'number', value: 0.7, start: 0, end: 1, numtype: 'number' }
+		]
 	},
 	{
 		selector: '-.3',
-		tokenize: [{ type: 'number', value: -0.3, sign: '-', start: 0, end: 2 }]
+		tokenize: [
+			{
+				type: 'number',
+				value: -0.3,
+				sign: '-',
+				start: 0,
+				end: 2,
+				numtype: 'number'
+			}
+		]
 	},
 	{
 		selector: '+637.54e-2',
-		tokenize: [{ type: 'number', value: 6.3754, sign: '+', start: 0, end: 9 }]
+		tokenize: [
+			{
+				type: 'number',
+				value: 6.3754,
+				sign: '+',
+				start: 0,
+				end: 9,
+				numtype: 'number'
+			}
+		]
 	},
 	{
 		selector: '-12.34E+2',
-		tokenize: [{ type: 'number', value: -1234, sign: '-', start: 0, end: 8 }]
+		tokenize: [
+			{
+				type: 'number',
+				value: -1234,
+				sign: '-',
+				start: 0,
+				end: 8,
+				numtype: 'number'
+			}
+		]
 	},
 	{
 		selector: '+ 5',
 		tokenize: [
 			{ type: 'delim', value: '+', start: 0, end: 0 },
 			{ type: 'whitespace', start: 1, end: 1 },
-			{ type: 'number', value: 5, start: 2, end: 2 }
+			{ type: 'number', value: 5, start: 2, end: 2, numtype: 'integer' }
 		]
 	},
 	{
 		selector: '-+12',
 		tokenize: [
 			{ type: 'delim', value: '-', start: 0, end: 0 },
-			{ type: 'number', value: 12, sign: '+', start: 1, end: 3 }
+			{
+				type: 'number',
+				value: 12,
+				sign: '+',
+				start: 1,
+				end: 3,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: '+-21',
 		tokenize: [
 			{ type: 'delim', value: '+', start: 0, end: 0 },
-			{ type: 'number', value: -21, sign: '-', start: 1, end: 3 }
+			{
+				type: 'number',
+				value: -21,
+				sign: '-',
+				start: 1,
+				end: 3,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: '++22',
 		tokenize: [
 			{ type: 'delim', value: '+', start: 0, end: 0 },
-			{ type: 'number', value: 22, sign: '+', start: 1, end: 3 }
+			{
+				type: 'number',
+				value: 22,
+				sign: '+',
+				start: 1,
+				end: 3,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: '13.',
 		tokenize: [
-			{ type: 'number', value: 13, start: 0, end: 1 },
+			{ type: 'number', value: 13, start: 0, end: 1, numtype: 'integer' },
 			{ type: 'delim', value: '.', start: 2, end: 2 }
 		]
 	},
 	{
 		selector: '1.e2',
 		tokenize: [
-			{ type: 'number', value: 1, start: 0, end: 0 },
+			{ type: 'number', value: 1, start: 0, end: 0, numtype: 'integer' },
 			{ type: 'delim', value: '.', start: 1, end: 1 },
 			{ type: 'ident', value: 'e2', start: 2, end: 3 }
 		]
@@ -927,35 +1016,63 @@ export default [
 	{
 		selector: '2e3.5',
 		tokenize: [
-			{ type: 'number', value: 2000, start: 0, end: 2 },
-			{ type: 'number', value: 0.5, start: 3, end: 4 }
+			{ type: 'number', value: 2000, start: 0, end: 2, numtype: 'number' },
+			{ type: 'number', value: 0.5, start: 3, end: 4, numtype: 'number' }
 		]
 	},
 	{
 		selector: '2e3.',
 		tokenize: [
-			{ type: 'number', value: 2000, start: 0, end: 2 },
+			{ type: 'number', value: 2000, start: 0, end: 2, numtype: 'number' },
 			{ type: 'delim', value: '.', start: 3, end: 3 }
 		]
 	},
 	{
 		selector: '1000000000000000000000000',
-		tokenize: [{ type: 'number', value: 1e24, start: 0, end: 24 }]
+		tokenize: [
+			{ type: 'number', value: 1e24, start: 0, end: 24, numtype: 'integer' }
+		]
 	},
 
 	// -- DimensionToken
 	{
 		selector: '10px',
-		tokenize: [{ type: 'dimension', value: 10, unit: 'px', start: 0, end: 3 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 10,
+				unit: 'px',
+				start: 0,
+				end: 3,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '12.0em',
-		tokenize: [{ type: 'dimension', value: 12, unit: 'em', start: 0, end: 5 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 12,
+				unit: 'em',
+				start: 0,
+				end: 5,
+				numtype: 'number'
+			}
+		]
 	},
 	{
 		selector: '-12.0em',
 		tokenize: [
-			{ type: 'dimension', value: -12, unit: 'em', sign: '-', start: 0, end: 6 }
+			{
+				type: 'dimension',
+				value: -12,
+				unit: 'em',
+				sign: '-',
+				start: 0,
+				end: 6,
+				numtype: 'number'
+			}
 		]
 	},
 	{
@@ -967,66 +1084,163 @@ export default [
 				unit: '__qem',
 				sign: '+',
 				start: 0,
-				end: 9
+				end: 9,
+				numtype: 'number'
 			}
 		]
 	},
 	{
 		selector: '5e',
-		tokenize: [{ type: 'dimension', value: 5, unit: 'e', start: 0, end: 1 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 5,
+				unit: 'e',
+				start: 0,
+				end: 1,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '5px-2px',
 		tokenize: [
-			{ type: 'dimension', value: 5, unit: 'px-2px', start: 0, end: 6 }
+			{
+				type: 'dimension',
+				value: 5,
+				unit: 'px-2px',
+				start: 0,
+				end: 6,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: '5e-',
-		tokenize: [{ type: 'dimension', value: 5, unit: 'e-', start: 0, end: 2 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 5,
+				unit: 'e-',
+				start: 0,
+				end: 2,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '5\\ ',
-		tokenize: [{ type: 'dimension', value: 5, unit: ' ', start: 0, end: 2 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 5,
+				unit: ' ',
+				start: 0,
+				end: 2,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '40\\70\\78',
-		tokenize: [{ type: 'dimension', value: 40, unit: 'px', start: 0, end: 7 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 40,
+				unit: 'px',
+				start: 0,
+				end: 7,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '4e3e2',
-		tokenize: [{ type: 'dimension', value: 4000, unit: 'e2', start: 0, end: 4 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 4000,
+				unit: 'e2',
+				start: 0,
+				end: 4,
+				numtype: 'number'
+			}
+		]
 	},
 	{
 		selector: '0x10px',
-		tokenize: [{ type: 'dimension', value: 0, unit: 'x10px', start: 0, end: 5 }]
+		tokenize: [
+			{
+				type: 'dimension',
+				value: 0,
+				unit: 'x10px',
+				start: 0,
+				end: 5,
+				numtype: 'integer'
+			}
+		]
 	},
 	{
 		selector: '4unit ',
 		tokenize: [
-			{ type: 'dimension', value: 4, unit: 'unit', start: 0, end: 4 },
+			{
+				type: 'dimension',
+				value: 4,
+				unit: 'unit',
+				start: 0,
+				end: 4,
+				numtype: 'integer'
+			},
 			{ type: 'whitespace', start: 5, end: 5 }
 		]
 	},
 	{
 		selector: '5e+',
 		tokenize: [
-			{ type: 'dimension', value: 5, unit: 'e', start: 0, end: 1 },
+			{
+				type: 'dimension',
+				value: 5,
+				unit: 'e',
+				start: 0,
+				end: 1,
+				numtype: 'integer'
+			},
 			{ type: 'delim', value: '+', start: 2, end: 2 }
 		]
 	},
 	{
 		selector: '2e.5',
 		tokenize: [
-			{ type: 'dimension', value: 2, unit: 'e', start: 0, end: 1 },
-			{ type: 'number', value: 0.5, start: 2, end: 3 }
+			{
+				type: 'dimension',
+				value: 2,
+				unit: 'e',
+				start: 0,
+				end: 1,
+				numtype: 'integer'
+			},
+			{ type: 'number', value: 0.5, start: 2, end: 3, numtype: 'number' }
 		]
 	},
 	{
 		selector: '2e+.5',
 		tokenize: [
-			{ type: 'dimension', value: 2, unit: 'e', start: 0, end: 1 },
-			{ type: 'number', value: 0.5, sign: '+', start: 2, end: 4 }
+			{
+				type: 'dimension',
+				value: 2,
+				unit: 'e',
+				start: 0,
+				end: 1,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: 0.5,
+				sign: '+',
+				start: 2,
+				end: 4,
+				numtype: 'number'
+			}
 		]
 	},
 
@@ -1062,24 +1276,66 @@ export default [
 		selector: 'u+012345-123456',
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
-			{ type: 'number', value: 12345, sign: '+', start: 1, end: 7 },
-			{ type: 'number', value: -123456, sign: '-', start: 8, end: 14 }
+			{
+				type: 'number',
+				value: 12345,
+				sign: '+',
+				start: 1,
+				end: 7,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: -123456,
+				sign: '-',
+				start: 8,
+				end: 14,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: 'U+1234-2345',
 		tokenize: [
 			{ type: 'ident', value: 'U', start: 0, end: 0 },
-			{ type: 'number', value: 1234, sign: '+', start: 1, end: 5 },
-			{ type: 'number', value: -2345, sign: '-', start: 6, end: 10 }
+			{
+				type: 'number',
+				value: 1234,
+				sign: '+',
+				start: 1,
+				end: 5,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: -2345,
+				sign: '-',
+				start: 6,
+				end: 10,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: 'u+222-111',
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
-			{ type: 'number', value: 222, sign: '+', start: 1, end: 4 },
-			{ type: 'number', value: -111, sign: '-', start: 5, end: 8 }
+			{
+				type: 'number',
+				value: 222,
+				sign: '+',
+				start: 1,
+				end: 4,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: -111,
+				sign: '-',
+				start: 5,
+				end: 8,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
@@ -1094,7 +1350,14 @@ export default [
 		selector: 'U+2??',
 		tokenize: [
 			{ type: 'ident', value: 'U', start: 0, end: 0 },
-			{ type: 'number', value: 2, sign: '+', start: 1, end: 2 },
+			{
+				type: 'number',
+				value: 2,
+				sign: '+',
+				start: 1,
+				end: 2,
+				numtype: 'integer'
+			},
 			{ type: 'delim', value: '?', start: 3, end: 3 },
 			{ type: 'delim', value: '?', start: 4, end: 4 }
 		]
@@ -1135,23 +1398,58 @@ export default [
 		selector: 'u+222+111',
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
-			{ type: 'number', value: 222, sign: '+', start: 1, end: 4 },
-			{ type: 'number', value: 111, sign: '+', start: 5, end: 8 }
+			{
+				type: 'number',
+				value: 222,
+				sign: '+',
+				start: 1,
+				end: 4,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: 111,
+				sign: '+',
+				start: 5,
+				end: 8,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: 'u+12345678',
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
-			{ type: 'number', value: 12345678, sign: '+', start: 1, end: 9 }
+			{
+				type: 'number',
+				value: 12345678,
+				sign: '+',
+				start: 1,
+				end: 9,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: 'u+123-12345678',
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
-			{ type: 'number', value: 123, sign: '+', start: 1, end: 4 },
-			{ type: 'number', value: -12345678, sign: '-', start: 5, end: 13 }
+			{
+				type: 'number',
+				value: 123,
+				sign: '+',
+				start: 1,
+				end: 4,
+				numtype: 'integer'
+			},
+			{
+				type: 'number',
+				value: -12345678,
+				sign: '-',
+				start: 5,
+				end: 13,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
@@ -1172,7 +1470,8 @@ export default [
 				unit: '-gggg',
 				sign: '+',
 				start: 1,
-				end: 10
+				end: 10,
+				numtype: 'integer'
 			}
 		]
 	},
@@ -1194,17 +1493,31 @@ export default [
 			{ type: 'delim', value: '+', start: 1, end: 1 },
 			{ type: 'ident', value: 'a1', start: 2, end: 3 },
 			{ type: 'delim', value: '?', start: 4, end: 4 },
-			{ type: 'number', value: -123, sign: '-', start: 5, end: 8 }
+			{
+				type: 'number',
+				value: -123,
+				sign: '-',
+				start: 5,
+				end: 8,
+				numtype: 'integer'
+			}
 		]
 	},
 	{
 		selector: 'u+1??4',
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
-			{ type: 'number', value: 1, sign: '+', start: 1, end: 2 },
+			{
+				type: 'number',
+				value: 1,
+				sign: '+',
+				start: 1,
+				end: 2,
+				numtype: 'integer'
+			},
 			{ type: 'delim', value: '?', start: 3, end: 3 },
 			{ type: 'delim', value: '?', start: 4, end: 4 },
-			{ type: 'number', value: 4, start: 5, end: 5 }
+			{ type: 'number', value: 4, start: 5, end: 5, numtype: 'integer' }
 		]
 	},
 	{
@@ -1227,7 +1540,14 @@ export default [
 		tokenize: [
 			{ type: 'ident', value: 'u', start: 0, end: 0 },
 			{ type: 'delim', value: '+', start: 1, end: 1 },
-			{ type: 'number', value: -543, sign: '-', start: 2, end: 5 }
+			{
+				type: 'number',
+				value: -543,
+				sign: '-',
+				start: 2,
+				end: 5,
+				numtype: 'integer'
+			}
 		]
 	},
 

--- a/test/cases/parse-css.case.js
+++ b/test/cases/parse-css.case.js
@@ -218,7 +218,7 @@ export default [
 		selector: '\r\n\f\t2',
 		tokenize: [
 			{ type: 'whitespace', start: 0, end: 2 },
-			{ type: 'number', value: 2, start: 3, end: 3, numtype: 'integer' }
+			{ type: 'number', value: 2, start: 3, end: 3, valtype: 'integer' }
 		]
 	},
 
@@ -462,7 +462,7 @@ export default [
 		selector: 'scale(2)',
 		tokenize: [
 			{ type: 'function', value: 'scale', start: 0, end: 5 },
-			{ type: 'number', value: 2, start: 6, end: 6, numtype: 'integer' },
+			{ type: 'number', value: 2, start: 6, end: 6, valtype: 'integer' },
 			{ type: ')', start: 7, end: 7 }
 		]
 	},
@@ -557,7 +557,7 @@ export default [
 		selector: '@2',
 		tokenize: [
 			{ type: 'delim', value: '@', start: 0, end: 0 },
-			{ type: 'number', value: 2, start: 1, end: 1, numtype: 'integer' }
+			{ type: 'number', value: 2, start: 1, end: 1, valtype: 'integer' }
 		]
 	},
 	{
@@ -570,7 +570,7 @@ export default [
 				sign: '-',
 				start: 1,
 				end: 2,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -786,20 +786,30 @@ export default [
 	{
 		selector: '#id-selector',
 		tokenize: [
-			{ type: 'hash', value: 'id-selector', id: true, start: 0, end: 11 }
+			{ type: 'hash', value: 'id-selector', valtype: 'id', start: 0, end: 11 }
 		]
 	},
 	{
 		selector: '#FF7700',
-		tokenize: [{ type: 'hash', value: 'FF7700', id: true, start: 0, end: 6 }]
+		tokenize: [
+			{ type: 'hash', value: 'FF7700', valtype: 'id', start: 0, end: 6 }
+		]
 	},
 	{
 		selector: '#3377FF',
-		tokenize: [{ type: 'hash', value: '3377FF', start: 0, end: 6 }]
+		tokenize: [
+			{
+				type: 'hash',
+				value: '3377FF',
+				valtype: 'unrestricted',
+				start: 0,
+				end: 6
+			}
+		]
 	},
 	{
 		selector: '#\\ ',
-		tokenize: [{ type: 'hash', value: ' ', id: true, start: 0, end: 2 }]
+		tokenize: [{ type: 'hash', value: ' ', valtype: 'id', start: 0, end: 2 }]
 	},
 	{
 		selector: '# ',
@@ -838,13 +848,13 @@ export default [
 	{
 		selector: '10',
 		tokenize: [
-			{ type: 'number', value: 10, start: 0, end: 1, numtype: 'integer' }
+			{ type: 'number', value: 10, start: 0, end: 1, valtype: 'integer' }
 		]
 	},
 	{
 		selector: '12.0',
 		tokenize: [
-			{ type: 'number', value: 12, start: 0, end: 3, numtype: 'number' }
+			{ type: 'number', value: 12, start: 0, end: 3, valtype: 'number' }
 		]
 	},
 	{
@@ -856,7 +866,7 @@ export default [
 				sign: '+',
 				start: 0,
 				end: 4,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -869,44 +879,44 @@ export default [
 				sign: '-',
 				start: 0,
 				end: 1,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
 	{
 		selector: '010',
 		tokenize: [
-			{ type: 'number', value: 10, start: 0, end: 2, numtype: 'integer' }
+			{ type: 'number', value: 10, start: 0, end: 2, valtype: 'integer' }
 		]
 	},
 	{
 		selector: '10e0',
 		tokenize: [
-			{ type: 'number', value: 10, start: 0, end: 3, numtype: 'number' }
+			{ type: 'number', value: 10, start: 0, end: 3, valtype: 'number' }
 		]
 	},
 	{
 		selector: '12e3',
 		tokenize: [
-			{ type: 'number', value: 12000, start: 0, end: 3, numtype: 'number' }
+			{ type: 'number', value: 12000, start: 0, end: 3, valtype: 'number' }
 		]
 	},
 	{
 		selector: '3e+1',
 		tokenize: [
-			{ type: 'number', value: 30, start: 0, end: 3, numtype: 'number' }
+			{ type: 'number', value: 30, start: 0, end: 3, valtype: 'number' }
 		]
 	},
 	{
 		selector: '12E-1',
 		tokenize: [
-			{ type: 'number', value: 1.2, start: 0, end: 4, numtype: 'number' }
+			{ type: 'number', value: 1.2, start: 0, end: 4, valtype: 'number' }
 		]
 	},
 	{
 		selector: '.7',
 		tokenize: [
-			{ type: 'number', value: 0.7, start: 0, end: 1, numtype: 'number' }
+			{ type: 'number', value: 0.7, start: 0, end: 1, valtype: 'number' }
 		]
 	},
 	{
@@ -918,7 +928,7 @@ export default [
 				sign: '-',
 				start: 0,
 				end: 2,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -931,7 +941,7 @@ export default [
 				sign: '+',
 				start: 0,
 				end: 9,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -944,7 +954,7 @@ export default [
 				sign: '-',
 				start: 0,
 				end: 8,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -953,7 +963,7 @@ export default [
 		tokenize: [
 			{ type: 'delim', value: '+', start: 0, end: 0 },
 			{ type: 'whitespace', start: 1, end: 1 },
-			{ type: 'number', value: 5, start: 2, end: 2, numtype: 'integer' }
+			{ type: 'number', value: 5, start: 2, end: 2, valtype: 'integer' }
 		]
 	},
 	{
@@ -966,7 +976,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 3,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -980,7 +990,7 @@ export default [
 				sign: '-',
 				start: 1,
 				end: 3,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -994,21 +1004,21 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 3,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
 	{
 		selector: '13.',
 		tokenize: [
-			{ type: 'number', value: 13, start: 0, end: 1, numtype: 'integer' },
+			{ type: 'number', value: 13, start: 0, end: 1, valtype: 'integer' },
 			{ type: 'delim', value: '.', start: 2, end: 2 }
 		]
 	},
 	{
 		selector: '1.e2',
 		tokenize: [
-			{ type: 'number', value: 1, start: 0, end: 0, numtype: 'integer' },
+			{ type: 'number', value: 1, start: 0, end: 0, valtype: 'integer' },
 			{ type: 'delim', value: '.', start: 1, end: 1 },
 			{ type: 'ident', value: 'e2', start: 2, end: 3 }
 		]
@@ -1016,21 +1026,21 @@ export default [
 	{
 		selector: '2e3.5',
 		tokenize: [
-			{ type: 'number', value: 2000, start: 0, end: 2, numtype: 'number' },
-			{ type: 'number', value: 0.5, start: 3, end: 4, numtype: 'number' }
+			{ type: 'number', value: 2000, start: 0, end: 2, valtype: 'number' },
+			{ type: 'number', value: 0.5, start: 3, end: 4, valtype: 'number' }
 		]
 	},
 	{
 		selector: '2e3.',
 		tokenize: [
-			{ type: 'number', value: 2000, start: 0, end: 2, numtype: 'number' },
+			{ type: 'number', value: 2000, start: 0, end: 2, valtype: 'number' },
 			{ type: 'delim', value: '.', start: 3, end: 3 }
 		]
 	},
 	{
 		selector: '1000000000000000000000000',
 		tokenize: [
-			{ type: 'number', value: 1e24, start: 0, end: 24, numtype: 'integer' }
+			{ type: 'number', value: 1e24, start: 0, end: 24, valtype: 'integer' }
 		]
 	},
 
@@ -1044,7 +1054,7 @@ export default [
 				unit: 'px',
 				start: 0,
 				end: 3,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1057,7 +1067,7 @@ export default [
 				unit: 'em',
 				start: 0,
 				end: 5,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -1071,7 +1081,7 @@ export default [
 				sign: '-',
 				start: 0,
 				end: 6,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -1085,7 +1095,7 @@ export default [
 				sign: '+',
 				start: 0,
 				end: 9,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -1098,7 +1108,7 @@ export default [
 				unit: 'e',
 				start: 0,
 				end: 1,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1111,7 +1121,7 @@ export default [
 				unit: 'px-2px',
 				start: 0,
 				end: 6,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1124,7 +1134,7 @@ export default [
 				unit: 'e-',
 				start: 0,
 				end: 2,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1137,7 +1147,7 @@ export default [
 				unit: ' ',
 				start: 0,
 				end: 2,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1150,7 +1160,7 @@ export default [
 				unit: 'px',
 				start: 0,
 				end: 7,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1163,7 +1173,7 @@ export default [
 				unit: 'e2',
 				start: 0,
 				end: 4,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -1176,7 +1186,7 @@ export default [
 				unit: 'x10px',
 				start: 0,
 				end: 5,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1189,7 +1199,7 @@ export default [
 				unit: 'unit',
 				start: 0,
 				end: 4,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'whitespace', start: 5, end: 5 }
 		]
@@ -1203,7 +1213,7 @@ export default [
 				unit: 'e',
 				start: 0,
 				end: 1,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'delim', value: '+', start: 2, end: 2 }
 		]
@@ -1217,9 +1227,9 @@ export default [
 				unit: 'e',
 				start: 0,
 				end: 1,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
-			{ type: 'number', value: 0.5, start: 2, end: 3, numtype: 'number' }
+			{ type: 'number', value: 0.5, start: 2, end: 3, valtype: 'number' }
 		]
 	},
 	{
@@ -1231,7 +1241,7 @@ export default [
 				unit: 'e',
 				start: 0,
 				end: 1,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -1239,7 +1249,7 @@ export default [
 				sign: '+',
 				start: 2,
 				end: 4,
-				numtype: 'number'
+				valtype: 'number'
 			}
 		]
 	},
@@ -1282,7 +1292,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 7,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -1290,7 +1300,7 @@ export default [
 				sign: '-',
 				start: 8,
 				end: 14,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1304,7 +1314,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 5,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -1312,7 +1322,7 @@ export default [
 				sign: '-',
 				start: 6,
 				end: 10,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1326,7 +1336,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 4,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -1334,7 +1344,7 @@ export default [
 				sign: '-',
 				start: 5,
 				end: 8,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1356,7 +1366,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 2,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'delim', value: '?', start: 3, end: 3 },
 			{ type: 'delim', value: '?', start: 4, end: 4 }
@@ -1404,7 +1414,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 4,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -1412,7 +1422,7 @@ export default [
 				sign: '+',
 				start: 5,
 				end: 8,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1426,7 +1436,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 9,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1440,7 +1450,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 4,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{
 				type: 'number',
@@ -1448,7 +1458,7 @@ export default [
 				sign: '-',
 				start: 5,
 				end: 13,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1471,7 +1481,7 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 10,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1499,7 +1509,7 @@ export default [
 				sign: '-',
 				start: 5,
 				end: 8,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},
@@ -1513,11 +1523,11 @@ export default [
 				sign: '+',
 				start: 1,
 				end: 2,
-				numtype: 'integer'
+				valtype: 'integer'
 			},
 			{ type: 'delim', value: '?', start: 3, end: 3 },
 			{ type: 'delim', value: '?', start: 4, end: 4 },
-			{ type: 'number', value: 4, start: 5, end: 5, numtype: 'integer' }
+			{ type: 'number', value: 4, start: 5, end: 5, valtype: 'integer' }
 		]
 	},
 	{
@@ -1546,7 +1556,7 @@ export default [
 				sign: '-',
 				start: 2,
 				end: 5,
-				numtype: 'integer'
+				valtype: 'integer'
 			}
 		]
 	},

--- a/test/css-tokenizer-tests.test.js
+++ b/test/css-tokenizer-tests.test.js
@@ -13,26 +13,31 @@ function adaptActual(tokens) {
 }
 
 function adaptExpected(tokens) {
-	return tokens.map(tok => {
-		const res = {
-			type: tok.type.replace(/\-token$/, '').toLowerCase()
-			// start: tok.startIndex,
-			// end: tok.endIndex - 1
-		};
-		if (tok.structured) {
-			res.value = tok.structured.value ?? undefined;
-			if (tok.structured.unit) {
-				res.unit = tok.structured.unit;
+	return tokens
+		.map(tok => {
+			const res = {
+				type: tok.type.replace(/\-token$/, '').toLowerCase()
+				// start: tok.startIndex,
+				// end: tok.endIndex - 1
+			};
+			if (tok.structured) {
+				res.value = tok.structured.value ?? undefined;
+				if (tok.structured.unit) {
+					res.unit = tok.structured.unit;
+				}
+				if (tok.structured.type) {
+					res.valtype = tok.structured.type;
+				}
+				if (tok.structured.signCharacter) {
+					res.sign = tok.structured.signCharacter;
+				}
 			}
-			if (tok.structured.type) {
-				res.valtype = tok.structured.type;
-			}
-			if (tok.structured.signCharacter) {
-				res.sign = tok.structured.signCharacter;
-			}
-		}
-		return res;
-	});
+			return res;
+		})
+		.filter(tok => {
+			// Selery does not emit comments
+			return tok.type !== 'comment';
+		});
 }
 
 Object.entries(testCorpus).forEach(entry => {

--- a/test/css-tokenizer-tests.test.js
+++ b/test/css-tokenizer-tests.test.js
@@ -62,24 +62,17 @@ function adaptActual(tokens, css) {
 			if (tok.unit) {
 				ret.structured.unit = tok.unit;
 			}
+			if (tok.numtype) {
+				ret.structured.type = tok.numtype;
+			}
 		}
 		return ret;
-	});
-}
-
-function adaptExpected(tokens) {
-	return tokens.map(tok => {
-		delete tok.structured?.type;
-		return tok;
 	});
 }
 
 Object.entries(testCorpus).forEach(entry => {
 	const [name, def] = entry;
 	test(name, t => {
-		assert.deepStrictEqual(
-			adaptActual(tokenize(def.css), def.css),
-			adaptExpected(def.tokens)
-		);
+		assert.deepStrictEqual(adaptActual(tokenize(def.css), def.css), def.tokens);
 	});
 });

--- a/test/css-tokenizer-tests.test.js
+++ b/test/css-tokenizer-tests.test.js
@@ -4,75 +4,43 @@ import assert from 'node:assert';
 import { testCorpus } from '@rmenke/css-tokenizer-tests';
 import { tokenize } from '../src/index.js';
 
-const TOKEN_TYPE_MAP = {
-	'at-keyword': 'at-keyword-token',
-	'bad-string': 'bad-string-token',
-	'bad-url': 'bad-url-token',
-	'}': '}-token',
-	'{': '{-token',
-	']': ']-token',
-	'[': '[-token',
-	cdc: 'cdc-token',
-	cdo: 'cdo-token',
-	colon: 'colon-token',
-	comma: 'comma-token',
-	delim: 'delim-token',
-	dimension: 'dimension-token',
-	function: 'function-token',
-	hash: 'hash-token',
-	ident: 'ident-token',
-	number: 'number-token',
-	')': ')-token',
-	'(': '(-token',
-	percentage: 'percentage-token',
-	semicolon: 'semicolon-token',
-	string: 'string-token',
-	unicode: 'unicode-token',
-	url: 'url-token',
-	whitespace: 'whitespace-token'
-};
-
-/*
-{
-	"type": "at-keyword-token",
-	"raw": "@foo",
-	"startIndex": 0,
-	"endIndex": 4,
-	"structured": {
-		"value": "foo"
-	}
-}
-*/
-function adaptActual(tokens, css) {
+function adaptActual(tokens) {
 	return tokens.map(tok => {
-		const ret = {
-			type: TOKEN_TYPE_MAP[tok.type],
-			raw: css.substring(tok.start, tok.end + 1),
-			startIndex: tok.start,
-			endIndex: tok.end + 1,
-			structured: null
+		delete tok.start;
+		delete tok.end;
+		return tok;
+	});
+}
+
+function adaptExpected(tokens) {
+	return tokens.map(tok => {
+		const res = {
+			type: tok.type.replace(/\-token$/, '').toLowerCase()
+			// start: tok.startIndex,
+			// end: tok.endIndex - 1
 		};
-		if (tok.value !== null && tok.value !== undefined) {
-			ret.structured = {
-				value: tok.value
-			};
-			if (tok.sign) {
-				ret.structured.signCharacter = tok.sign;
+		if (tok.structured) {
+			res.value = tok.structured.value ?? undefined;
+			if (tok.structured.unit) {
+				res.unit = tok.structured.unit;
 			}
-			if (tok.unit) {
-				ret.structured.unit = tok.unit;
+			if (tok.structured.type) {
+				res.valtype = tok.structured.type;
 			}
-			if (tok.numtype) {
-				ret.structured.type = tok.numtype;
+			if (tok.structured.signCharacter) {
+				res.sign = tok.structured.signCharacter;
 			}
 		}
-		return ret;
+		return res;
 	});
 }
 
 Object.entries(testCorpus).forEach(entry => {
 	const [name, def] = entry;
 	test(name, t => {
-		assert.deepStrictEqual(adaptActual(tokenize(def.css), def.css), def.tokens);
+		assert.deepStrictEqual(
+			adaptActual(tokenize(def.css)),
+			adaptExpected(def.tokens)
+		);
 	});
 });

--- a/test/css-tokenizer-tests.test.js
+++ b/test/css-tokenizer-tests.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { testCorpus } from '@rmenke/css-tokenizer-tests';
+import { tokenize } from '../src/index.js';
+
+const TOKEN_TYPE_MAP = {
+	'at-keyword': 'at-keyword-token',
+	'bad-string': 'bad-string-token',
+	'bad-url': 'bad-url-token',
+	'}': '}-token',
+	'{': '{-token',
+	']': ']-token',
+	'[': '[-token',
+	cdc: 'cdc-token',
+	cdo: 'cdo-token',
+	colon: 'colon-token',
+	comma: 'comma-token',
+	delim: 'delim-token',
+	dimension: 'dimension-token',
+	function: 'function-token',
+	hash: 'hash-token',
+	ident: 'ident-token',
+	number: 'number-token',
+	')': ')-token',
+	'(': '(-token',
+	percentage: 'percentage-token',
+	semicolon: 'semicolon-token',
+	string: 'string-token',
+	unicode: 'unicode-token',
+	url: 'url-token',
+	whitespace: 'whitespace-token'
+};
+
+/*
+{
+	"type": "at-keyword-token",
+	"raw": "@foo",
+	"startIndex": 0,
+	"endIndex": 4,
+	"structured": {
+		"value": "foo"
+	}
+}
+*/
+function adaptActual(tokens, css) {
+	return tokens.map(tok => {
+		const ret = {
+			type: TOKEN_TYPE_MAP[tok.type],
+			raw: css.substring(tok.start, tok.end + 1),
+			startIndex: tok.start,
+			endIndex: tok.end + 1,
+			structured: null
+		};
+		if (tok.value !== null && tok.value !== undefined) {
+			ret.structured = {
+				value: tok.value
+			};
+			if (tok.sign) {
+				ret.structured.signCharacter = tok.sign;
+			}
+			if (tok.unit) {
+				ret.structured.unit = tok.unit;
+			}
+		}
+		return ret;
+	});
+}
+
+function adaptExpected(tokens) {
+	return tokens.map(tok => {
+		delete tok.structured?.type;
+		return tok;
+	});
+}
+
+Object.entries(testCorpus).forEach(entry => {
+	const [name, def] = entry;
+	test(name, t => {
+		assert.deepStrictEqual(
+			adaptActual(tokenize(def.css), def.css),
+			adaptExpected(def.tokens)
+		);
+	});
+});


### PR DESCRIPTION
Changes to the tokenizer:

* Switches to a single `valtype` property to store the _type_ flag for various tokens, as expressed in the spec.
* Stop throwing on parser errors (see also #14)

To adapt the test cases:

* we don’t check `startIndex` and `endIndex`, since in the tests they use UTF-16 (a.k.a. normal array) indices, and we use UTF-8 codepoint indices for `start` and `end` — this should probably be reflected in the docs, along with a way to read a slice of the string.

Still left to do:

* [ ] Handle bad-string cases
* [ ] Handle bad-url cases